### PR TITLE
fix validation of subns name for let's encrypt delegation

### DIFF
--- a/html/libs/primary.php
+++ b/html/libs/primary.php
@@ -3865,7 +3865,7 @@ class Primary extends Zone {
   function checkSUBNSName($string) {
     $string = strtolower($string);
     // allow only one underscore
-    if (count(explode('_',$string,2))>1)
+    if (count(explode('_',$string,3))>2)
       return 0;
     $allowed = "_0123456789abcdefghijklmnopqrstuvwxyz-";
     if (ereg('\.ip6\.arpa$', $this->zonename)) $allowed = "." . $allowed;


### PR DESCRIPTION
Validation code was not allowing a single underscore (as stated in the
comment), making it unable to delegate `_acme-challenge` for Let's
Encrypt DNS-01 validation.